### PR TITLE
Added ability to send multiple roses in one command

### DIFF
--- a/handlers/roses.coffee
+++ b/handlers/roses.coffee
@@ -106,7 +106,6 @@ handleMessage = (message, callback) ->
 					return
 					
 				if usernames.length > 10
-					usernames = usernames.splice 0, 10
 					api.replyTo message, __("You must not enter more than 10 usernames in one command!"), no, callback
 					return
 				

--- a/handlers/roses.coffee
+++ b/handlers/roses.coffee
@@ -107,7 +107,8 @@ handleMessage = (message, callback) ->
 					
 				if usernames.length > 10
 					usernames = usernames.splice 0, 10
-					api.replyTo message, __("You must not enter more than 10 usernames in one command!"), no
+					api.replyTo message, __("You must not enter more than 10 usernames in one command!"), no, callback
+					return
 				
 				async.eachSeries usernames, (username, callback) ->
 					db.getUserByUsername username, (err, user) ->


### PR DESCRIPTION
This misses german translations for the phrases »No valid username given.« and »You must not enter more than 10 usernames in one command!« because the locales are not part of this repository.

Functionality has been tested with a local instance of the chatbot in a live chat environment.